### PR TITLE
Fix puma security warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 log/
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@
 source "https://rubygems.org"
 
 gem 'sinatra', '2.0.8', require: 'sinatra/base'
-gem 'puma', '>= 3.12.2'
+gem 'puma', '4.3.3'
 
-gem 'neo4j', '>= 8.2.1'
-gem 'neo4j-core', '>= 7.2.3'
+gem 'neo4j', '8.2.1'
+gem 'neo4j-core', '7.2.3'
 gem 'haml'
 
 gem 'sinatra-contrib', require: 'sinatra/reloader'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,62 +1,69 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.4.1)
-      activesupport (= 5.2.4.1)
-    activesupport (5.2.4.1)
+    activemodel (5.2.4.2)
+      activesupport (= 5.2.4.2)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     backports (3.15.0)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     ethon (0.12.0)
       ffi (>= 1.3.0)
     faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
+    faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
     faraday_middleware-multi_json (0.0.6)
       faraday_middleware
       multi_json
-    ffi (1.11.3)
+    ffi (1.12.2)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
     httpclient (2.8.3)
-    i18n (1.7.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
-    minitest (5.13.0)
+    minitest (5.14.0)
     multi_json (1.14.1)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    neo4j (9.6.1)
+    neo4j (8.2.1)
       activemodel (>= 4.0)
       activesupport (>= 4.0)
-      i18n (!= 1.3.0)
-      neo4j-core (>= 9.0.0)
+      neo4j-core (>= 7.2.2)
       orm_adapter (~> 0.5.0)
-    neo4j-core (9.0.0)
+    neo4j-core (7.2.3)
       activesupport (>= 4.0)
       faraday (>= 0.9.0)
-      faraday_middleware (>= 0.10.0)
+      faraday_middleware (~> 0.10.0)
       faraday_middleware-multi_json
       httpclient
       json
       multi_json
-      net_tcp_client (>= 2.0.1)
+      neo4j-rake_tasks (>= 0.3.0)
       typhoeus (>= 1.1.2)
-    net_tcp_client (2.2.0)
+    neo4j-rake_tasks (0.7.19)
+      os
+      rake
+      ruby-progressbar
+      rubyzip (>= 1.1.7)
     nio4r (2.5.2)
     orm_adapter (0.5.0)
-    puma (4.3.1)
+    os (1.1.0)
+    puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.0.8)
     rack-protection (2.0.8)
       rack
+    rake (13.0.1)
+    ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.1)
+    rubyzip (2.3.0)
     sinatra (2.0.8)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -74,7 +81,7 @@ GEM
     tilt (2.0.10)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
 
 PLATFORMS
@@ -82,9 +89,9 @@ PLATFORMS
 
 DEPENDENCIES
   haml
-  neo4j (>= 8.2.1)
-  neo4j-core (>= 7.2.3)
-  puma (>= 3.12.2)
+  neo4j (= 8.2.1)
+  neo4j-core (= 7.2.3)
+  puma (= 4.3.3)
   sinatra (= 2.0.8)
   sinatra-contrib
 


### PR DESCRIPTION
Got this working locally for the updated sinatra gem- needed to lock the neo4j gems in place to avoid a breaking change.